### PR TITLE
Add: scaling function for multi-device

### DIFF
--- a/packages/mobile/src/styles/builder/utils.ts
+++ b/packages/mobile/src/styles/builder/utils.ts
@@ -1,4 +1,5 @@
-import { Platform } from "react-native";
+import { Dimensions, Platform, StyleSheet } from "react-native";
+const { height, width } = Dimensions.get("window");
 
 type FontWeightNumbers =
   | "100"
@@ -32,6 +33,57 @@ const FontWeightTypesMap: { [key in FontWeightTypes]: FontWeightNumbers } = {
   bold: "700",
   extrabold: "800",
   black: "900",
+};
+
+//iphone 13
+const baseWidth = 390;
+const baseHeight = 844;
+
+export const isTablet = height / width < 1.6;
+
+/**
+ *
+ * @param {number} size
+ * @returns {number}
+ * ex: paddingTop: scale(16), fontSize: scale(16), marginLeft: scale(8)
+ */
+export const scale = (size: number): number => {
+  if (isTablet) {
+    return (height / baseHeight) * size;
+  } else {
+    return (width / baseWidth) * size;
+  }
+};
+
+/**
+ * Apply scale to numeric values ​​in style
+ * @param {Record<string, unknown>} style - The style object needs to have scale applied
+ * @param {boolean} [isScale=true] - Flag to determine whether scaling is applied or not (optional), default is true
+ * @returns {Record<string, unknown> | undefined} - The style object has scale applied or undefined if the style is undefined
+ * ex: 
+ * <OWButton
+    style={styleWithScale(styles.btnOW)}
+    size="default"
+    label="Create a new wallet"
+    onPress={handleCreateANewWallet}
+  />
+ */
+export const styleWithScale = (
+  style: Record<string, unknown>,
+  isScale = true
+) => {
+  if (style === undefined) {
+    return undefined;
+  }
+  const flattenedStyle = StyleSheet.flatten(style);
+  const scaledEntries = Object.entries(flattenedStyle).map(([key, value]) => {
+    if (typeof value === "number" && !["flex", "opacity"].includes(key)) {
+      return [key, isScale ? scale(value) : value];
+    }
+    return [key, value];
+  });
+
+  return Object.fromEntries(scaledEntries);
 };
 
 export function getPlatformFontWeight(


### PR DESCRIPTION
**We need more users? We need to grow faster?** However, we have not yet met good UI and UX standards. To maximize and optimize the user experience on devices like iPads and tablets, I have added a scale function. This function calculates and returns corresponding values to prevent layout issues on large screen devices, especially on Samsung Fold and Z Flip.

And here is the difference when using and not using the scale function:
### _welcome Screen:_

1. without scale:

![welcome_without_scale](https://github.com/user-attachments/assets/e105526a-f663-484a-af61-44b85b58f64b)

2. with scale

![welcome_with_scale](https://github.com/user-attachments/assets/2ed1f5a3-1f1e-4315-8fea-3f5dc7ec89c2)

### _create new wallet screen:_

1. without scale:

![newWallet_without_scale](https://github.com/user-attachments/assets/a139c04a-e8dd-4970-9215-ef30f06914cc)

2. with scale

![newWallet_with_scale](https://github.com/user-attachments/assets/9451605c-e78f-4b2f-b3d2-5c530a82ee00)

### **and on popular mobile devices there is almost no difference**

1. _without scale:_

![Ip_without_scale](https://github.com/user-attachments/assets/f58562be-4fbc-41a7-a7b9-7b9337d9ce15)

2. _with scale_

![Ip_with_scale](https://github.com/user-attachments/assets/b96b3684-c879-4280-925f-1e9900a93034)

