### PR TITLE
Add `Rootstock` chain

### DIFF
--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -690,6 +690,57 @@ export const EmbedChainInfos: ChainInfo[] = [
     features: ["not-support-staking"],
   },
   {
+    rpc: "https://public-node.rsk.co",
+    rest: "https://public-node.rsk.co",
+    evm: {
+      chainId: 30,
+      rpc: "https://public-node.rsk.co",
+      websocket: "wss://rootstock.drpc.org",
+    },
+    chainId: "eip155:30",
+    chainName: "Rootstock",
+    chainSymbolImageUrl:
+      "https://raw.githubusercontent.com/rsksmart/rsk-contract-metadata/master/images/rootstock-orange.png",
+    bip44: {
+      coinType: 137,
+    },
+    currencies: [
+      {
+        coinDenom: "RBTC",
+        coinMinimalDenom: "rootstock-native",
+        coinDecimals: 18,
+        coinGeckoId: "rootstock",
+        coinImageUrl:
+          "https://coin-images.coingecko.com/coins/images/5070/large/RBTC-logo.png",
+      },
+      {
+        type: "erc20",
+        coinDenom: "RIF",
+        coinMinimalDenom: "erc20:0x2acc95758f8b5f583470ba265eb685a8f45fc9d5",
+        coinDecimals: 18,
+        coinGeckoId: "rif-token",
+        coinImageUrl:
+          "https://raw.githubusercontent.com/rsksmart/rsk-contract-metadata/refs/heads/master/images/rif.png",
+      }
+    ],
+    feeCurrencies: [
+      {
+        coinDenom: "RBTC",
+        coinMinimalDenom: "rootstock-native",
+        coinDecimals: 18,
+        coinGeckoId: "rootstock",
+        coinImageUrl:
+          "https://coin-images.coingecko.com/coins/images/5070/large/RBTC-logo.png",
+      },
+    ],
+    features: ["not-support-staking"],
+    txExplorer: {
+      name: "Rootstock Explorer",
+      txUrl: "https://explorer.rootstock.io/tx/{txHash}",
+      accountUrl: "https://explorer.rootstock.io/address/{address}",
+    },
+  },
+  {
     rpc: "https://cosmos-rpc.owallet.io",
     rest: "https://cosmos-rest.owallet.io",
     chainId: "cosmoshub-4",

--- a/packages/stores-eth/src/queries/coingecko-token-info.ts
+++ b/packages/stores-eth/src/queries/coingecko-token-info.ts
@@ -81,6 +81,7 @@ const coingeckoChainIdMap: Record<string, string> = {
   "eip155:56": Network.BINANCE_SMART_CHAIN,
   "eip155:10": "optimistic-ethereum",
   "eip155:137": "polygon-pos",
+  "eip155:30": "rootstock",
   "eip155:8453": "base",
   "eip155:42161": "arbitrum-one",
 };


### PR DESCRIPTION
## Description

This PR adds [Rootstock](https://rootstock.io/) network to owallet. Rootstock is **EVM compatible** and supported by the leading developer tools; oracles, indexers, Rootstock is the most advanced and complete infrastructure for building on Bitcoin.

## About Rootstock
Website: https://rootstock.io/
Defillama: https://defillama.com/chain/Rootstock
Explorer: https://explorer.rootstock.io/
Developer portal: https://dev.rootstock.io/

Please review this pull request and feel free to let me know/comment if there any changes required.