### PR TITLE
Hotfix/popup permission

### DIFF
--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -100,7 +100,6 @@ export class KeyRingCosmosService {
 
   async getKey(vaultId: string, chainId: string): Promise<Key> {
     const chainInfo = this.chainsService.getChainInfoOrThrow(chainId);
-    console.log(chainId, "chainInfo from getKey");
     if (chainInfo.features.includes("gen-address")) {
       throw new Error(
         `${chainInfo.chainId} not support getKey from keyring cosmos base`

--- a/packages/background/src/keyring-ethereum/handler.ts
+++ b/packages/background/src/keyring-ethereum/handler.ts
@@ -69,7 +69,7 @@ const handleRequestJsonRpcToEvmMsg: (
   permissionInteractionService
 ) => {
   return async (env, msg) => {
-    if (msg.method !== "owallet_initProviderState") {
+    if (msg.method === "eth_requestAccounts") {
       await permissionInteractionService.ensureEnabledForEVM(env, msg.origin);
     }
 

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -1294,7 +1294,8 @@ class EthereumProvider extends EventEmitter implements IEthereumProvider {
       throw new Error("Invalid paramater: `method` must be a string");
     }
 
-    if (method !== "owallet_initProviderState") {
+    // Only request permission for eth_requestAccounts, not for all methods
+    if (method === "eth_requestAccounts") {
       await this.protectedEnableAccess();
     }
 
@@ -2204,7 +2205,8 @@ class TronProvider extends EventEmitter implements ITronProvider {
       throw new Error("Invalid paramater: `method` must be a string");
     }
 
-    if (method !== "owallet_initProviderState") {
+    // Only request permission for eth_requestAccounts, not for all methods
+    if (method === "eth_requestAccounts") {
       await this.protectedEnableAccess();
     }
 


### PR DESCRIPTION
Fix the issue where \"Requesting Connection\" popup appeared automatically
on dApp page load instead of only appearing when user explicitly clicks
\"Connect Wallet\".

Root Causes Fixed:
1. Provider auto-permission (PRIMARY): EthereumProvider and TronProvider
   in core.ts were calling protectedEnableAccess() for ALL RPC methods
   except owallet_initProviderState. Now only calls for eth_requestAccounts.

2. Backend service: KeyRingEthereumService.request() was triggering
   permission popup for all methods when currentChainId was null. Now only
   triggers for eth_requestAccounts, throws error 4100 for other methods.

3. Handler layer: handleRequestJsonRpcToEvmMsg was calling ensureEnabledForEVM
   for all methods. Now only calls for eth_requestAccounts.